### PR TITLE
Setting num_workers = 0

### DIFF
--- a/multi_person_tracker/mpt.py
+++ b/multi_person_tracker/mpt.py
@@ -189,7 +189,7 @@ class MPT():
 
         image_dataset = ImageFolder(image_folder)
 
-        dataloader = DataLoader(image_dataset, batch_size=self.batch_size, num_workers=8)
+        dataloader = DataLoader(image_dataset, batch_size=self.batch_size, num_workers=0)
 
         trackers = self.run_tracker(dataloader)
         if self.display:


### PR DESCRIPTION
Set num_workers to 0 so that it uses max available. The current setting, num_workers=8, will cause the multi-person-tracker to be killed by the OS if there are not 8 threads available, which was the case even in on a newish MacBook pro. 